### PR TITLE
Scale pokemon image to container edges

### DIFF
--- a/src/components/CyberpunkTrainerDossier.tsx
+++ b/src/components/CyberpunkTrainerDossier.tsx
@@ -540,7 +540,7 @@ const CyberpunkTrainerDossier: React.FC<CyberpunkTrainerDossierProps> = ({
                       <img
                         src={profPic}
                         alt='Hartley H. Leroy'
-                        className='w-full h-full object-cover scale-110 cyberpunk-id-photo'
+                        className='w-full h-full object-fill scale-150 cyberpunk-id-photo'
                       />
                     </div>
                     {/* Sprite Glow Effect */}


### PR DESCRIPTION
Scale the Pokemon card image to touch the purple container's edges.

The `object-cover` property was changed to `object-fill` and `scale-110` to `scale-150` to ensure the image completely fills and extends beyond the container boundaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-df134907-0a2e-4fc9-a8c0-a04d6e948db1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df134907-0a2e-4fc9-a8c0-a04d6e948db1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

