### PR TITLE
Scale pokemon image to container edges

### DIFF
--- a/ai-jank/CyberpunkTrainerCard.tsx
+++ b/ai-jank/CyberpunkTrainerCard.tsx
@@ -471,7 +471,7 @@ const CyberpunkTrainerCard: React.FC<CyberpunkTrainerCardProps> = ({
                       <img
                         src={characterProfile}
                         alt='Character Profile'
-                        className='w-full h-full object-contain object-center rounded-lg'
+                        className='w-full h-full object-cover object-center rounded-lg'
                         style={{}}
                       />
                       <div


### PR DESCRIPTION
Update CyberpunkTrainerCard to scale the character image to fill its container by changing `object-contain` to `object-cover`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b4abb2c-7b13-4b2b-b2ec-750bce905d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b4abb2c-7b13-4b2b-b2ec-750bce905d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

