### PR TITLE
Revert scaling and fit width

### DIFF
--- a/src/components/CyberpunkTrainerDossier.tsx
+++ b/src/components/CyberpunkTrainerDossier.tsx
@@ -540,7 +540,7 @@ const CyberpunkTrainerDossier: React.FC<CyberpunkTrainerDossierProps> = ({
                       <img
                         src={profPic}
                         alt='Hartley H. Leroy'
-                        className='w-full h-full object-fill scale-150 cyberpunk-id-photo'
+                        className='w-full h-auto object-contain cyberpunk-id-photo'
                       />
                     </div>
                     {/* Sprite Glow Effect */}


### PR DESCRIPTION
Revert profile image scaling and adjust height to `auto` to ensure it fills the width while maintaining its aspect ratio.

---
<a href="https://cursor.com/background-agent?bcId=bc-719832cd-8328-46a5-86d6-ad82bb2fb915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-719832cd-8328-46a5-86d6-ad82bb2fb915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

