### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,5 +1,8 @@
 name: Development Build & Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/hhleroy97/hhl_site/security/code-scanning/3](https://github.com/hhleroy97/hhl_site/security/code-scanning/3)

To fix this problem, add an explicit `permissions` block to the workflow. The block should be placed at the root level, or inside each job if you want more granular control. For this workflow, adding at the root is simplest and applies defaults to all jobs. The minimal necessary permissions are `contents: read`, which allows actions to read repository code/artifacts. No write permissions are needed, as the workflow does not push code or modify issues/pull requests.

The change should be made at the top of `.github/workflows/dev.yml`, below the `name:` and above `on:` (for workflow-wide permissions), or could be inside every job block. The preferred fix is to add the following after the `name:` block:

```yaml
permissions:
  contents: read
```

No additional library imports, methods, or definitions are needed; this is a simple YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
